### PR TITLE
docs(Template): update location of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Thank you for opening a Pull Request!
+
+---
+
+Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
+- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
+- [ ] Ensure the tests and linter pass
+- [ ] Code coverage does not decrease (if any source code was changed)
+- [ ] Appropriate docs were updated (if necessary)
+
+Fixes #<issue_number_goes_here> 🦕


### PR DESCRIPTION
Move location of PR template since the previous location was not applying the template on new PRs. The template was only being applied if you add the URL query param .\n\nAlso, I removed the header that applies the  label since that only seemed to work on issues and not PRs.